### PR TITLE
Add basic RT search support 

### DIFF
--- a/splunkrepl.js
+++ b/splunkrepl.js
@@ -254,85 +254,87 @@ function doQuery(query, callback) {
                 job.results({}, done);
             });
         },
-        function(results, job, done) {
-            if (results.rows.length == 0) {
-                if (useJson) {
-                    console.log("[]");
-                    return done();
-                }
-                console.log("-- NO RESULTS --".yellow);
-                return done();
-            }
-            var fields={};
-            
-            var isStats = results.fields.indexOf("_raw") === -1;
-            if (!isStats) {
-                fields["_time"] = results.fields.indexOf("_time");
-            }
-            results.fields.forEach(function(fieldName, index) {
-                if (fieldName != "_time")
-                    fields[fieldName] = index;
-            });
-   
-            if (!verbose) {
-                delete fields['_bkt'];
-                delete fields['_si'];
-                delete  fields['_cd'];
-                delete fields['_indextime'];
-                delete fields['_serial'];
-                delete fields['linecount'];
-                delete fields['_sourcetype'];
-                delete fields['splunk_server'];
-            }
-            var head = [];
-
-            for (var fieldName in fields) {
-                head.push(fieldName.cyan.bold);
-            }
-
-            var table = new Table({head:head});
-
-            var events=[];
-
-            results.rows.forEach(function(result){
-                var event = {};
-                var vals = [];
-                for(var fieldName in fields) {
-                    if(isStats) {
-                        var val = result[fields[fieldName]] || '';
-                        vals.push(val.white.bold); 
-                    }
-                    event[fieldName] = result[fields[fieldName]];
-                }
-                if (useJson) {
-                    events.push(event);
-                }
-                else {
-                    if (isStats)
-                    {
-                        table.push(vals);
-                    }
-                    else 
-                    {
-                        console.log("\n" + prettyjson.render(event));
-                        console.log("---------------------------------------------".grey);
-                    }
-                }
-            });
-            if (useJson & events.length > 0) {
-                console.log(JSON.stringify(events, null, 2));
-            }
-            if (isStats) {
-                console.log(table.toString());
-            }
-            done();
-        }]
+        outputResults]
     , function(err) {
         if (err) {
             handleError(err, callback);
         }
         return callback(" ");
     });    
+}
+
+function outputResults(results, job, done) {
+    if (results.rows.length == 0) {
+        if (useJson) {
+            console.log("[]");
+            return done();
+        }
+        console.log("-- NO RESULTS --".yellow);
+        return done();
+    }
+    var fields={};
+
+    var isStats = results.fields.indexOf("_raw") === -1;
+    if (!isStats) {
+        fields["_time"] = results.fields.indexOf("_time");
+    }
+    results.fields.forEach(function(fieldName, index) {
+        if (fieldName != "_time")
+            fields[fieldName] = index;
+    });
+
+    if (!verbose) {
+        delete fields['_bkt'];
+        delete fields['_si'];
+        delete  fields['_cd'];
+        delete fields['_indextime'];
+        delete fields['_serial'];
+        delete fields['linecount'];
+        delete fields['_sourcetype'];
+        delete fields['splunk_server'];
+    }
+    var head = [];
+
+    for (var fieldName in fields) {
+        head.push(fieldName.cyan.bold);
+    }
+
+    var table = new Table({head:head});
+
+    var events=[];
+
+    results.rows.forEach(function(result){
+        var event = {};
+        var vals = [];
+        for(var fieldName in fields) {
+            if(isStats) {
+                var val = result[fields[fieldName]] || '';
+                vals.push(val.white.bold);
+            }
+            event[fieldName] = result[fields[fieldName]];
+        }
+        if (useJson) {
+            events.push(event);
+        }
+        else {
+            if (isStats)
+            {
+                table.push(vals);
+            }
+            else
+            {
+                console.log("\n" + prettyjson.render(event));
+                console.log("---------------------------------------------".grey);
+            }
+        }
+    });
+    if (useJson & events.length > 0) {
+        console.log(JSON.stringify(events, null, 2));
+    }
+    if (isStats) {
+        console.log(table.toString());
+    }
+    done();
 }
 
 function handleError(err, callback) {

--- a/splunkrepl.js
+++ b/splunkrepl.js
@@ -273,7 +273,7 @@ function doQuery(query, callback) {
 }
 
 function outputResults(results) {
-    if (results.rows.length == 0) {
+    if (!results || !results.rows || results.rows.length == 0) {
         if (useJson) {
             console.log("[]");
             return;

--- a/splunkrepl.js
+++ b/splunkrepl.js
@@ -249,12 +249,21 @@ function doQuery(query, callback) {
         function(success, done) {
             self.service.search(search, {}, done);
         },
-        function(job, done) {
-            job.track({}, function(job) {
-                job.results({}, done);
+        function (job, done) {
+            job.track({}, {
+                done: function (job) {
+                    job.results({}, function (err, results, job) {
+                        if (err) {
+                            console.log(err);
+                        } else {
+                            outputResults(results);
+                        }
+                        done(err);
+                    });
+                }
             });
-        },
-        outputResults]
+        }
+    ]
     , function(err) {
         if (err) {
             handleError(err, callback);
@@ -263,14 +272,14 @@ function doQuery(query, callback) {
     });    
 }
 
-function outputResults(results, job, done) {
+function outputResults(results) {
     if (results.rows.length == 0) {
         if (useJson) {
             console.log("[]");
-            return done();
+            return;
         }
         console.log("-- NO RESULTS --".yellow);
-        return done();
+        return;
     }
     var fields={};
 
@@ -334,7 +343,6 @@ function outputResults(results, job, done) {
     if (isStats) {
         console.log(table.toString());
     }
-    done();
 }
 
 function handleError(err, callback) {


### PR DESCRIPTION
Adds initial support for real-time searches (#6)
- Use ':rt query' to start a real-time search
  - New events should be printed as they arrive
- The repl can be used while rt search is ongoing – prompt indicates a running rt search
- Starting a second rt search stops the first one
- Use ':exit' to end a running rt search

Open questions:
- Not sure about using :exit to end real-time query, introduce separate command?
- Abillity to use repl while rt search is running can be confusing (new events are printed while typing a command)
- New events are output as chunks, which could be improved, e.g. json output should be [{},{},{}] instead of (invalid) [{},{}][{},{},{}] – similar for tables. not an issue with regular output
- Had to change prompt/repl eval handling a bit – possible issue? what was the original motivation behind the --hosted flag?
- Tell splunk sdk to discard search results at some point (if possible) – otherwise this is a memory black hole?
