### PR TITLE
Fixing truncated --query

### DIFF
--- a/splunkrepl.js
+++ b/splunkrepl.js
@@ -195,7 +195,7 @@ function eval(cmd, context, filename, callback) {
         process.stdout.write("spl query>".green);
     }
 
-    cmd = cmd.substring(0, cmd.length -1);
+    cmd = cmd.trim();
 
     if (cmd === "?" || cmd === ":help") {
         cmd_help(callback);


### PR DESCRIPTION
Previously using the --query option would result in the query getting truncated by one character, i.e. index=_internal would actually search for: index=_interna

Replacing the character removal with trim() still cleans newlines (which I guess was the original intention), but only if there are any.
